### PR TITLE
Add gzip compression as an option

### DIFF
--- a/tracker/emitter_test.go
+++ b/tracker/emitter_test.go
@@ -58,6 +58,7 @@ func TestEmitterInit(t *testing.T) {
 	assert.NotNil(emitter.HttpClient)
 	assert.NotNil(emitter.Storage)
 	assert.Equal("memory.StorageMemory", reflect.TypeOf(emitter.Storage).String())
+	assert.False(emitter.EnableRequestPostGzip)
 
 	// Assert defaults
 	emitter = InitEmitter(RequireCollectorUri("com.acme"), RequireStorage(*sqlite3.Init("test.db")))
@@ -75,6 +76,7 @@ func TestEmitterInit(t *testing.T) {
 	assert.NotNil(emitter.HttpClient)
 	assert.NotNil(emitter.Storage)
 	assert.Equal("sqlite3.StorageSQLite3", reflect.TypeOf(emitter.Storage).String())
+	assert.False(emitter.EnableRequestPostGzip)
 
 	// Assert the set functions
 	emitter.SetCollectorUri("com.snplow")


### PR DESCRIPTION
This is a simple PR to test out GZIP compression on a tracker and can be used to validate whether or not it gives sufficient gains to be worth pursuing as a formal integration with the Snowplow Collector.