### PR TITLE
Bump Ubuntu Version in GH Actions  (Close #83)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         go-version: ${{ matrix.go }}
         
     - name: Cache go modules
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        go: [ '1.19', '1.18', '1.17' ]
+        go: [ '1.24', '1.23', '1.22' ]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
This PR bumps the Ubuntu version in CI, and updates the testing matrix to the latest supported versions of Go.