### PR TITLE
Fix race conditions in Emitter for concurrent usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ tidy:
 test:
 	mkdir -p $(coverage_dir)
 	GO111MODULE=on go install golang.org/x/tools/cmd/cover@latest
-	GO111MODULE=on go test ./... -tags test -v -covermode=count -coverprofile=$(coverage_out)
+	GO111MODULE=on go test ./... -tags test -v -race -covermode=atomic -coverprofile=$(coverage_out)
 	GO111MODULE=on go tool cover -html=$(coverage_out) -o $(coverage_html)
 
 goveralls: test

--- a/tracker/emitter.go
+++ b/tracker/emitter.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/snowplow/snowplow-golang-tracker/v3/pkg/common"
@@ -62,6 +63,8 @@ type Emitter struct {
 	SendChannel   chan bool
 	Callback      func(successCount []CallbackResult, failureCount []CallbackResult)
 	HttpClient    *http.Client
+	sendMu        sync.Mutex
+	configMu      sync.RWMutex
 }
 
 // InitEmitter creates a new Emitter object which handles
@@ -183,18 +186,31 @@ func (e *Emitter) Flush() {
 
 // Stop waits for the send channel to have a value and then resets it to nil.
 func (e *Emitter) Stop() {
-	<-e.SendChannel
-	e.SendChannel = nil
+	e.sendMu.Lock()
+	ch := e.SendChannel
+	e.sendMu.Unlock()
+
+	if ch != nil {
+		<-ch // Wait for completion outside the lock
+
+		e.sendMu.Lock()
+		e.SendChannel = nil
+		e.sendMu.Unlock()
+	}
 }
 
 // start will begin the sending loop.
 func (e *Emitter) start() {
-	if e.SendChannel == nil || !e.IsSending() {
+	e.sendMu.Lock()
+	if e.SendChannel == nil || !e.isSending() {
 		e.SendChannel = make(chan bool, 1)
+		ch := e.SendChannel // Capture channel reference before releasing lock
+		e.sendMu.Unlock()
+
 		go func() {
 			var done bool
 			defer func() {
-				e.SendChannel <- done
+				ch <- done // Send to captured channel to avoid race
 			}()
 
 			for {
@@ -237,25 +253,34 @@ func (e *Emitter) start() {
 			}
 			done = true
 		}()
+		return
 	}
+	e.sendMu.Unlock()
 }
 
 // doSend will send all of the eventsRows it is given.
 func (e *Emitter) doSend(eventRows []storageiface.EventRow) []SendResult {
 	futures := []<-chan SendResult{}
-	url := e.GetCollectorUrl()
 
-	if e.RequestType == "POST" {
+	// Read configuration under lock
+	e.configMu.RLock()
+	url := e.CollectorUrl.String()
+	requestType := e.RequestType
+	byteLimitGet := e.ByteLimitGet
+	byteLimitPost := e.ByteLimitPost
+	e.configMu.RUnlock()
+
+	if requestType == "POST" {
 		ids := []int{}
 		payloads := []payload.Payload{}
 		totalByteSize := 0
 
 		for _, val := range eventRows {
 			byteSize := common.CountBytesInString(val.Event.String()) + POST_STM_BYTES
-			if byteSize+POST_WRAPPER_BYTES > e.ByteLimitPost {
+			if byteSize+POST_WRAPPER_BYTES > byteLimitPost {
 				// A single payload has exceeded the Byte Limit
 				futures = append(futures, e.sendPostRequest(url, []int{val.Id}, []payload.Payload{val.Event}, true))
-			} else if (totalByteSize + byteSize + POST_WRAPPER_BYTES + (len(payloads) - 1)) > e.ByteLimitPost {
+			} else if (totalByteSize + byteSize + POST_WRAPPER_BYTES + (len(payloads) - 1)) > byteLimitPost {
 				// Byte limit reached
 				futures = append(futures, e.sendPostRequest(url, ids, payloads, false))
 
@@ -272,11 +297,11 @@ func (e *Emitter) doSend(eventRows []storageiface.EventRow) []SendResult {
 		if len(payloads) > 0 {
 			futures = append(futures, e.sendPostRequest(url, ids, payloads, false))
 		}
-	} else if e.RequestType == "GET" {
+	} else if requestType == "GET" {
 		for _, val := range eventRows {
 			val.Event.Add(SENT_TIMESTAMP, common.NewString(common.GetTimestampString()))
 			queryString := common.MapToQueryParams(val.Event.Get()).Encode()
-			oversize := common.CountBytesInString(queryString) > e.ByteLimitGet
+			oversize := common.CountBytesInString(queryString) > byteLimitGet
 			futures = append(futures, e.sendGetRequest(url+"?"+queryString, []int{val.Id}, oversize))
 		}
 	}
@@ -367,8 +392,15 @@ func (e *Emitter) sendPostRequest(url string, ids []int, body []payload.Payload,
 // --- Helpers
 
 // IsSending checks whether the send channel has finished.
-func (e Emitter) IsSending() bool {
-	return len(e.SendChannel) == 0
+func (e *Emitter) IsSending() bool {
+	e.sendMu.Lock()
+	defer e.sendMu.Unlock()
+	return e.isSending()
+}
+
+// isSending is the internal helper (caller must hold lock).
+func (e *Emitter) isSending() bool {
+	return e.SendChannel != nil && len(e.SendChannel) == 0
 }
 
 // returnCollectorUrl builds and returns the full collector URL to be used.
@@ -399,33 +431,56 @@ func addSentTimeToEvents(events []payload.Payload) []map[string]string {
 // --- Getters & Setters
 
 // GetCollectorUrl returns the stringified collector URL.
-func (e Emitter) GetCollectorUrl() string {
+func (e *Emitter) GetCollectorUrl() string {
+	e.configMu.RLock()
+	defer e.configMu.RUnlock()
 	return e.CollectorUrl.String()
 }
 
 // SetCollectorUri sets a new Collector URI and updates the Collector URL.
 func (e *Emitter) SetCollectorUri(collectorUri string) {
-	collectorUrl, err := returnCollectorUrl(e.RequestType, e.Protocol, collectorUri)
+	e.configMu.RLock()
+	requestType := e.RequestType
+	protocol := e.Protocol
+	e.configMu.RUnlock()
+
+	collectorUrl, err := returnCollectorUrl(requestType, protocol, collectorUri)
 	if err == nil {
+		e.configMu.Lock()
 		e.CollectorUrl = *collectorUrl
 		e.CollectorUri = collectorUri
+		e.configMu.Unlock()
 	}
 }
 
 // SetRequestType sets a new Request Type and updates the Collector URL.
 func (e *Emitter) SetRequestType(requestType string) {
-	collectorUrl, err := returnCollectorUrl(requestType, e.Protocol, e.CollectorUri)
+	e.configMu.RLock()
+	protocol := e.Protocol
+	collectorUri := e.CollectorUri
+	e.configMu.RUnlock()
+
+	collectorUrl, err := returnCollectorUrl(requestType, protocol, collectorUri)
 	if err == nil {
+		e.configMu.Lock()
 		e.CollectorUrl = *collectorUrl
 		e.RequestType = requestType
+		e.configMu.Unlock()
 	}
 }
 
 // SetProtocol sets a new Protocol and updates the Collector URL.
 func (e *Emitter) SetProtocol(protocol string) {
-	collectorUrl, err := returnCollectorUrl(e.RequestType, protocol, e.CollectorUri)
+	e.configMu.RLock()
+	requestType := e.RequestType
+	collectorUri := e.CollectorUri
+	e.configMu.RUnlock()
+
+	collectorUrl, err := returnCollectorUrl(requestType, protocol, collectorUri)
 	if err == nil {
+		e.configMu.Lock()
 		e.CollectorUrl = *collectorUrl
 		e.Protocol = protocol
+		e.configMu.Unlock()
 	}
 }

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -271,6 +271,7 @@ func TestTrackFunctionsFailingGET(t *testing.T) {
 
 	tracker.TrackPageView(PageViewEvent{PageUrl: common.NewString("acme.com")})
 	tracker.BlockingFlush(5, 10)
+	tracker.Emitter.Stop() // Wait for all emitter goroutines to finish before httpmock cleanup
 }
 
 func TestTrackFunctionsFailingPOST(t *testing.T) {
@@ -305,6 +306,7 @@ func TestTrackFunctionsFailingPOST(t *testing.T) {
 
 	tracker.TrackPageView(PageViewEvent{PageUrl: common.NewString("acme.com")})
 	tracker.BlockingFlush(5, 10)
+	tracker.Emitter.Stop() // Wait for all emitter goroutines to finish before httpmock cleanup
 }
 
 func TestTrackFunctionsWithEventSubject(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR fixes multiple race conditions in the `Emitter` that occur when the tracker is used concurrently from multiple goroutines. These issues were discovered when running tests with Go's race detector (`-race` flag), which can be observed with commit 9736ae1e79fbc16a766bdb7d1a9920a11b3e8a20.

## Problem

The current implementation has three race conditions:

### 1. SendChannel race in `start()` and `Stop()`
The `start()` method uses a check-then-act pattern without synchronization:
```go
if e.SendChannel == nil || !e.IsSending() {
    e.SendChannel = make(chan bool, 1)  // Race: multiple goroutines can enter here
    // ...
}
```

When multiple goroutines call tracker methods concurrently, they can simultaneously check `SendChannel`, both see it as `nil`, and both try to create it, causing a data race.

### 2. Configuration field races in `doSend()`
The `doSend()` method reads configuration fields (`CollectorUrl`, `RequestType`, `ByteLimitGet`, `ByteLimitPost`) without synchronization while setter methods (`SetCollectorUri`, `SetRequestType`, etc.) can modify them concurrently.

### 3. Test cleanup races
Tests using `httpmock` experience races when `DeactivateAndReset()` is called while emitter goroutines are still making HTTP requests.

## Solution

### Added two mutexes to `Emitter`:
- `sendMu sync.Mutex` - Protects `SendChannel` lifecycle operations
- `configMu sync.RWMutex` - Protects configuration fields (allows concurrent reads)

### Key changes:
1. **Protected `start()` and `Stop()`** - All `SendChannel` access now under `sendMu` lock
2. **Protected `doSend()`** - Reads configuration under `configMu.RLock()` before processing
3. **Protected getters/setters** - All configuration access now synchronized
4. **Fixed test cleanup** - Added `Emitter.Stop()` calls in failing tests to wait for goroutines

## Testing

### Before (with race detector):
```bash
$ go test ./tracker/... -race
==================
WARNING: DATA RACE
Read at 0x... by goroutine 123:
  github.com/snowplow/snowplow-golang-tracker/v3/tracker.(*Emitter).start()
      .../tracker/emitter.go:193
Previous write at 0x... by goroutine 124:
  github.com/snowplow/snowplow-golang-tracker/v3/tracker.(*Emitter).start()
      .../tracker/emitter.go:193
==================
Found 6+ data races
FAIL
```

https://github.com/joaodrp/snowplow-golang-tracker/actions/runs/19546149791/job/55965315500

### After (with race detector):

✅ **0 race conditions detected**

https://github.com/joaodrp/snowplow-golang-tracker/actions/runs/19631283123/job/56211438908

